### PR TITLE
DockerLatentWorker buildargs option fix

### DIFF
--- a/master/buildbot/worker/docker.py
+++ b/master/buildbot/worker/docker.py
@@ -271,6 +271,7 @@ class DockerLatentWorker(DockerBaseWorker,
                 lines = docker_client.build(
                     fileobj=BytesIO(dockerfile.encode('utf-8')),
                     tag=image,
+                    buildargs=buildargs
                 )
 
             for line in lines:


### PR DESCRIPTION
DockerLatentWorker: buildargs option enabled with custom_context = False
